### PR TITLE
Getting the organization name into the query URL.

### DIFF
--- a/source/src/main/java/com/apigee/sdk/data/client/DataClient.java
+++ b/source/src/main/java/com/apigee/sdk/data/client/DataClient.java
@@ -1558,12 +1558,12 @@ public class DataClient implements LocationListener {
 	 * @param ql
 	 * @param callback
 	 */
-	public void queryUsersAsync(String ql, QueryResultsCallback callback) {
-		Map<String, Object> params = new HashMap<String, Object>();
-		params.put("ql", ql);
-		queryEntitiesRequestAsync(callback, HTTP_METHOD_GET, params, null,
-				getApplicationId(), "users");
-	}
+    public void queryUsersAsync(String ql, QueryResultsCallback callback) {
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("ql", ql);
+        queryEntitiesRequestAsync(callback, HTTP_METHOD_GET, params, null, 
+                getOrganizationId(), getApplicationId(), "users");
+    }
 	
     /**
      * Perform a query of the users collection within the specified distance of


### PR DESCRIPTION
The resulting URL lacked the org name, so I added a call to getOrganizationId() to the param list.
