### PR TITLE
USERGRID-3043: added appId to ClientSessionMetrics (not sure why, or how...

### DIFF
--- a/source/src/main/java/com/apigee/sdk/apm/android/AbstractUploadService.java
+++ b/source/src/main/java/com/apigee/sdk/apm/android/AbstractUploadService.java
@@ -190,6 +190,18 @@ public abstract class AbstractUploadService implements MetricsUploadService {
 			sessionMetrics.setSessionStartTime(sessionManager.getSessionStartTime());
 			sessionMetrics.setSdkVersion(MonitoringClient.getSDKVersion());
 			sessionMetrics.setSdkType(MonitoringClient.getDevicePlatform());
+			
+			// application Id
+			ApplicationConfigurationService configService = monitoringClient.getApplicationConfigurationService();
+			if (null != configService) {
+				App app = configService.getCompositeApplicationConfigurationModel();
+				if( app != null ) {
+					Long instaOpsAppId = app.getInstaOpsApplicationId();
+					if (instaOpsAppId != null) {
+						sessionMetrics.setAppId(instaOpsAppId);
+					}
+				}
+			}
 
 			//setting all the fields which rely on different permissions.
 			//TODO: double check if there is a permission that could prohibit SDK from getting application version

--- a/source/src/main/java/com/apigee/sdk/apm/android/model/ClientSessionMetrics.java
+++ b/source/src/main/java/com/apigee/sdk/apm/android/model/ClientSessionMetrics.java
@@ -13,6 +13,8 @@ public class ClientSessionMetrics implements Serializable {
 	 */
 	private static final long serialVersionUID = 1L;
 
+	Long appId;
+
 	String sessionId;
 
 	//if location is enabled in manifest and location capture is allowed.
@@ -128,6 +130,15 @@ public class ClientSessionMetrics implements Serializable {
 	private Long endWeek;
 
 	private Long endMonth;
+
+	
+	public Long getAppId() {
+		return appId;
+	}
+
+	public void setAppId(Long appId) {
+		this.appId = appId;
+	}
 
 	public String getAppConfigType() {
 		if (this.appConfigType == null)


### PR DESCRIPTION
... long, it’s been missing).
