### PR TITLE
Fixed bug in queryEntityConnectionsAsync

### DIFF
--- a/source/src/main/java/com/apigee/sdk/data/client/DataClient.java
+++ b/source/src/main/java/com/apigee/sdk/data/client/DataClient.java
@@ -2435,7 +2435,7 @@ public class DataClient implements LocationListener {
 		params.put("ql", makeLocationQL(distance, location.getLatitude(), location.getLongitude(), ql));
 		params.put("ql", ql);
 		queryEntitiesRequestAsync(callback, HTTP_METHOD_GET, params, null,
-				getApplicationId(), getApplicationId(), connectingEntityType, connectingEntityId,
+				getOrganizationId(), getApplicationId(), connectingEntityType, connectingEntityId,
 				connectionType);
 	}
 	

--- a/source/src/main/java/com/apigee/sdk/data/client/DataClient.java
+++ b/source/src/main/java/com/apigee/sdk/data/client/DataClient.java
@@ -2435,7 +2435,7 @@ public class DataClient implements LocationListener {
 		params.put("ql", makeLocationQL(distance, location.getLatitude(), location.getLongitude(), ql));
 		params.put("ql", ql);
 		queryEntitiesRequestAsync(callback, HTTP_METHOD_GET, params, null,
-				getApplicationId(), connectingEntityType, connectingEntityId,
+				getApplicationId(), getApplicationId(), connectingEntityType, connectingEntityId,
 				connectionType);
 	}
 	

--- a/source/src/main/java/com/apigee/sdk/data/client/DataClient.java
+++ b/source/src/main/java/com/apigee/sdk/data/client/DataClient.java
@@ -2345,7 +2345,7 @@ public class DataClient implements LocationListener {
     public Query queryEntityConnections(String connectingEntityType,
             String connectingEntityId, String connectionType, String ql) {
         Map<String, Object> params = new HashMap<String, Object>();
-        params.put("ql", ql);
+        params.put("ql", ql);        
         Query q = queryEntitiesRequest(HTTP_METHOD_GET, params, null,
                 organizationId, applicationId, connectingEntityType, connectingEntityId,
                 connectionType);
@@ -2370,9 +2370,9 @@ public class DataClient implements LocationListener {
 			String connectingEntityId, String connectionType, String ql,
 			QueryResultsCallback callback) {
 		Map<String, Object> params = new HashMap<String, Object>();
-		params.put("ql", ql);
+        params.put("ql", ql);        
 		queryEntitiesRequestAsync(callback, HTTP_METHOD_GET, params, null,
-				getApplicationId(), connectingEntityType, connectingEntityId,
+				getOrganizationId(), getApplicationId(), connectingEntityType, connectingEntityId,
 				connectionType);
 	}
 	


### PR DESCRIPTION
queryEntityConnectionsAsync was not sending org name when called, causing api requests to fail
